### PR TITLE
릴리즈 종료로 인한 main, develop 브랜치 병합을 진행합니다.

### DIFF
--- a/helios-main/src/API/Search.ts
+++ b/helios-main/src/API/Search.ts
@@ -2,10 +2,12 @@ import axios from "axios";
 
 const CCTV_API_BASE_URL = import.meta.env.VITE_CCTV_API_URL;
 
+// 검색을 위해 사용하는 파라미터 데이터 타입
 export interface SearchRequest {
   query: string;
 }
 
+// 검색 결과 데이터 타입
 export interface SearchResponse {
   id: number;
   roadsectionid: string;
@@ -20,6 +22,7 @@ export interface SearchResponse {
   cctvurl_pre: null;
 }
 
+// 가공할 데이터 타입
 export interface SearchModel {
   id: number;
   cctvType: number;
@@ -31,21 +34,26 @@ export interface SearchModel {
   cctvUrlPre: null;
 }
 
+// axios 인스턴스 생성
 const apiClient = axios.create({
   baseURL: CCTV_API_BASE_URL,
   timeout: 500000,
 });
 
+// 검색 API 호출 함수
 export const fetchSearchData = async (
   body: SearchRequest
 ): Promise<SearchModel[]> => {
   const response = await apiClient.get<{ data: SearchResponse[] }>(
-    "cctv/search",
-    { params: { search: body.query } }
+    "cctv/search", // 검색 주소
+    { params: { search: body.query } } // 파라미터
   );
 
+  // 응답 데이터
   const raw = response.data.data;
 
+
+  // 데이터 가공
   return raw.map((item) => ({
     id: item.id,
     cctvType: item.cctvtype,

--- a/helios-main/src/components/DetectionHistory/DetectionHistoryContent.tsx
+++ b/helios-main/src/components/DetectionHistory/DetectionHistoryContent.tsx
@@ -31,25 +31,29 @@ export default function DetectionHistoryContent({
     staleTime: 60 * 1000,
   });
 
+  // 탐지 기록 데이터
   const detectionListData = DetectionListQuery.data || [];
 
   // 검색이 있을 때 검색 결과 제공, 없으면 전체 데이터 제공
   const baseDetections = useMemo(() => {
-    const q = (searchData ?? "").trim();
-    if (!q) return detectionListData as DetectionModel[];
+    const q = (searchData ?? "").trim(); // 검색어 공백 제거
+    if (!q) return detectionListData as DetectionModel[]; // 검색어 없으면 전체 데이터
 
-    const results = (searchResultQuery.data ?? []) as { id: number | string }[];
-    if (!results || results.length === 0) return [];
+    const results = (searchResultQuery.data ?? []) as { id: number | string }[]; // 검색 결과 저장
+    if (!results || results.length === 0) return []; // 검색 결과 없으면 빈 배열
 
-    const idSet = new Set<number>(
+    const idSet = new Set<number>( // 검색 결과 ID 집합
       results.map((r) => Number(r.id)).filter((n) => Number.isFinite(n))
     );
-    return (detectionListData as DetectionModel[]).filter((d) =>
-      idSet.has(Number(d.id))
+    return (detectionListData as DetectionModel[]).filter(
+      (
+        d //검색 결과 리턴 (id 제공)
+      ) => idSet.has(Number(d.id))
     );
   }, [detectionListData, searchData, searchResultQuery.data]);
 
-  // - labelFilter가 없으면 전체 컨테츠 제공
+  // 검색 기능 이전 코드
+  // - labelFilter가 없으면 전체 컨텐츠 제공
   // - labelFilter가 있으면 해당 라벨을 가진 CCTV만 남김
   // const filteredDetections = useMemo(() => {
   //   if (!labelFilter) return detectionListData;
@@ -58,6 +62,7 @@ export default function DetectionHistoryContent({
   //   );
   // }, [detectionListData, labelFilter]);
 
+  // 필터링된 탐지 기록 데이터 (라벨 필터), 검색 기록과 비교에서 검색이 존재하면 검색 결과 제공
   const filteredDetections = useMemo(() => {
     if (!labelFilter) return baseDetections;
     return baseDetections.filter((item) =>
@@ -112,6 +117,7 @@ export default function DetectionHistoryContent({
     return pages;
   };
 
+  // 페이지네이션 버튼 목록
   const pageNumbers = useMemo(
     () => getPageNumbers(totalPages, currentPage),
     [totalPages, currentPage]
@@ -139,6 +145,7 @@ export default function DetectionHistoryContent({
   // HLS attach: 모달이 열릴 때 .m3u8 재생 시도
   const videoRef = React.useRef<HTMLVideoElement | null>(null);
 
+  // playerOpen 또는 playerUrl이 바뀔 때마다 재생 시도
   useEffect(() => {
     if (!playerOpen || !playerUrl) return;
     const video = videoRef.current;

--- a/helios-main/src/components/DetectionHistory/HistoryPageSlogan.tsx
+++ b/helios-main/src/components/DetectionHistory/HistoryPageSlogan.tsx
@@ -3,9 +3,7 @@ import { useQuery } from "@tanstack/react-query";
 import { fetchDetectionData } from "../../API/Detection";
 import type { DetectionModel } from "../../API/Detection";
 export default function HistoryPageSlogan() {
-  // ---------------------------------------------
   // 실데이터 로딩 (DetectionModel[])
-  // ---------------------------------------------
   const { data: detections = [] } = useQuery<DetectionModel[]>({
     queryKey: ["detectionList"],
     queryFn: fetchDetectionData,
@@ -15,24 +13,34 @@ export default function HistoryPageSlogan() {
   // 유틸: 건수 → 상태 매핑 (팀 정책)
   const getStatusInfo = (count: number) => {
     if (count >= 2) return { status: "위험" as const, color: "red" as const };
-    if (count >= 1) return { status: "주의" as const, color: "yellow" as const };
+    if (count >= 1)
+      return { status: "주의" as const, color: "yellow" as const };
     return { status: "안전" as const, color: "green" as const };
   };
 
   // 위험/주의 구간 집계 (각 CCTV 별 탐지 건수 기반)
   const dangerCount = useMemo(
-    () => detections.filter((d) => getStatusInfo(d.detections.length).status === "위험").length,
+    () =>
+      detections.filter(
+        (d) => getStatusInfo(d.detections.length).status === "위험"
+      ).length,
     [detections]
   );
   const warningCount = useMemo(
-    () => detections.filter((d) => getStatusInfo(d.detections.length).status === "주의").length,
+    () =>
+      detections.filter(
+        (d) => getStatusInfo(d.detections.length).status === "주의"
+      ).length,
     [detections]
   );
 
   // 마지막 업데이트: 가장 최근 date (동일 일시 스펙 → 그대로 최대값 사용)
   const lastUpdatedLabel = useMemo(() => {
     if (detections.length === 0) return "-";
-    const maxDate = detections.reduce((acc, cur) => (cur.date > acc ? cur.date : acc), detections[0].date);
+    const maxDate = detections.reduce(
+      (acc, cur) => (cur.date > acc ? cur.date : acc),
+      detections[0].date
+    );
     // 오늘 여부 판단 후 라벨 결정
     const now = new Date();
     const isSameYMD =
@@ -77,7 +85,9 @@ export default function HistoryPageSlogan() {
             <div className="bg-white p-4 rounded-xl shadow-sm border border-gray-100">
               <div className="flex items-center gap-3">
                 <div>
-                  <div className="text-xl font-[700] text-red-600">{dangerCount}</div>
+                  <div className="text-xl font-[700] text-red-600">
+                    {dangerCount}
+                  </div>
                   <div className="text-sm text-gray-600">위험 구간</div>
                 </div>
               </div>
@@ -86,7 +96,9 @@ export default function HistoryPageSlogan() {
             <div className="bg-white p-4 rounded-xl shadow-sm border border-gray-100">
               <div className="flex items-center gap-3">
                 <div>
-                  <div className="text-xl font-[700] text-yellow-600">{warningCount}</div>
+                  <div className="text-xl font-[700] text-yellow-600">
+                    {warningCount}
+                  </div>
                   <div className="text-sm text-gray-600">주의 구간</div>
                 </div>
               </div>
@@ -95,7 +107,9 @@ export default function HistoryPageSlogan() {
             <div className="bg-white p-4 rounded-xl shadow-sm border border-gray-100">
               <div className="flex items-center gap-3">
                 <div>
-                  <div className="text-xl font-[700] text-blue-600">{lastUpdatedLabel}</div>
+                  <div className="text-xl font-[700] text-blue-600">
+                    {lastUpdatedLabel}
+                  </div>
                   <div className="text-sm text-gray-600">마지막 업데이트</div>
                 </div>
               </div>


### PR DESCRIPTION
## Describe

탐지 기록 페이지와 CCTV 검색 기능을 중심으로 API 연동 작업을 진행한 결과에 대한 릴리즈를 진행합니다.
사용자는 분석 데이터와 CCTV 검색 기능을 통해 파손 정보를 확인할 수 있습니다.

1. 탐지 기록 API 연동
- 서버에서 제공하는 탐지기록 API를 Axios, React Query 기반으로 연동
- 10개 단위의 페이지네이션 적용

2. 파손 API 연동
- YOLOv8n이 탐지한 도로 파손 데이터를 저장한 API를 Axios, React Query 기반으로 연동
- 파손 갯수에 따라 임시로 위험도 평가 진행

3. CCTV 검색 API 연동
- CCTV 이름기반으로 검색할 수 있는 API를 Axios, React Query 기반으로 연동
- 검색 시 해당 CCTV만 필터링되어 확인 가능

릴리즈를 통해 버그 확인, 가독성을 위한 주석을 추가했습니다.